### PR TITLE
New rule for detecting linux command executing via ProcessBuilder

### DIFF
--- a/00178.json
+++ b/00178.json
@@ -1,0 +1,18 @@
+{
+    "crime": "Execute Linux commands via ProcessBuilder",
+    "permission": [],
+    "api": [
+        {
+            "class": "Ljava/lang/ProcessBuilder;",
+            "method": "<init>",
+            "descriptor": "([Ljava/lang/String;)V",
+        },
+        {
+            "class": "Ljava/lang/ProcessBuilder;",
+            "method": "start",
+            "descriptor": "()Ljava/lang/Process;",
+        },
+    ],
+    "score": 1,
+    "label": ["command"],
+}


### PR DESCRIPTION
from sample: b6f3e633b41192c47d53eecfaa3f6a5b6bb37e768ef4e843869d6d6d11432dc8
![](https://i.imgur.com/SirlVkn.png)
