### PR TITLE
Fix malformed json

### DIFF
--- a/00178.json
+++ b/00178.json
@@ -5,14 +5,14 @@
         {
             "class": "Ljava/lang/ProcessBuilder;",
             "method": "<init>",
-            "descriptor": "([Ljava/lang/String;)V",
+            "descriptor": "([Ljava/lang/String;)V"
         },
         {
             "class": "Ljava/lang/ProcessBuilder;",
             "method": "start",
-            "descriptor": "()Ljava/lang/Process;",
-        },
+            "descriptor": "()Ljava/lang/Process;"
+        }
     ],
     "score": 1,
-    "label": ["command"],
+    "label": ["command"]
 }


### PR DESCRIPTION
The rule `00178.json` was malformed which caused Quark to fail when parsing the rule.

The error was :
```
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 9 column 9 (char 248)
```