### PR TITLE
Add rules for BladeHawk

### DIFF
--- a/00182.json
+++ b/00182.json
@@ -1,0 +1,19 @@
+{
+    "crime": "Open camera.",
+    "permission": [],
+    "api": [
+        {
+            "class": "Landroid/hardware/Camera;",
+            "method": "open",
+            "descriptor": "(I)Landroid/hardware/Camera;"
+        },
+        {
+            "class": "Ljava/lang/Object;",
+            "method": "<init>",
+            "descriptor": "()V"
+        }
+    ],
+    "score": 1,
+    "label": ["camera"],
+    "malware": ["4b65291d3453664b214cf2b0cfd0cd5d"]
+}

--- a/00183.json
+++ b/00183.json
@@ -1,0 +1,19 @@
+{
+    "crime": "Get current camera paremeters and change the setting.",
+    "permission": [],
+    "api": [
+        {
+            "class": "Landroid/hardware/Camera;",
+            "method": "getParameters",
+            "descriptor": "()Landroid/hardware/Camera$Parameters;"
+        },
+        {
+            "class": "Landroid/hardware/Camera;",
+            "method": "setParameters",
+            "descriptor": "(Landroid/hardware/Camera$Parameters;)V"
+        }
+    ],
+    "score": 1,
+    "label": ["camera"],
+    "malware": ["4b65291d3453664b214cf2b0cfd0cd5d"]
+}

--- a/00184.json
+++ b/00184.json
@@ -1,0 +1,19 @@
+{
+    "crime": "Set camera preview texture",
+    "permission": [],
+    "api": [
+        {
+            "class": "Landroid/hardware/Camera;",
+            "method": "setPreviewTexture",
+            "descriptor": "(Landroid/graphics/SurfaceTexture;)V"
+        },
+        {
+            "class": "Ljava/lang/Object;",
+            "method": "<init>",
+            "descriptor": "()V"
+        }
+    ],
+    "score": 1,
+    "label": ["camera"],
+    "malware": ["4b65291d3453664b214cf2b0cfd0cd5d"]
+}

--- a/00185.json
+++ b/00185.json
@@ -1,0 +1,19 @@
+{
+    "crime": "Start capturing camera preview frames to the screen",
+    "permission": [],
+    "api": [
+        {
+            "class": "Landroid/hardware/Camera;",
+            "method": "startPreview",
+            "descriptor": "()V"
+        },
+        {
+            "class": "Ljava/lang/Object;",
+            "method": "<init>",
+            "descriptor": "()V"
+        }
+    ],
+    "score": 1,
+    "label": ["camera"],
+    "malware": ["4b65291d3453664b214cf2b0cfd0cd5d"]
+}

--- a/00186.json
+++ b/00186.json
@@ -1,0 +1,19 @@
+{
+    "crime": "Control camera to take picture",
+    "permission": [],
+    "api": [
+        {
+            "class": "Ljava/lang/Object;",
+            "method": "<init>",
+            "descriptor": "()V"
+        },
+        {
+            "class": "Landroid/hardware/Camera;",
+            "method": "takePicture",
+            "descriptor": "(Landroid/hardware/Camera$ShutterCallback; Landroid/hardware/Camera$PictureCallback; Landroid/hardware/Camera$PictureCallback;)V"
+        }
+    ],
+    "score": 1,
+    "label": ["camera"],
+    "malware": ["4b65291d3453664b214cf2b0cfd0cd5d"]
+}


### PR DESCRIPTION
The new ruleset detects camera control in the samples related to the malware family.