### PR TITLE
Restore rules/00004.json which was accidentally deleted

### DIFF
--- a/rules/00004.json
+++ b/rules/00004.json
@@ -1,0 +1,21 @@
+{
+    "crime": "Get filename and put it to JSON object",
+    "permission": [],
+    "api": [
+        {
+            "class": "Ljava/io/File;",
+            "method": "getName",
+            "descriptor": "()Ljava/lang/String;"
+        },
+        {
+            "class": "Lorg/json/JSONObject;",
+            "method": "put",
+            "descriptor": "(Ljava/lang/String; Ljava/lang/Object;)Lorg/json/JSONObject;"
+        }
+    ],
+    "score": 0.76,
+    "label": [
+        "file",
+        "collection"
+    ]
+}


### PR DESCRIPTION
This PR restores `rules/00004.json` which was accidentally deleted by #57.