### PR TITLE
Restore rules/00188.json which was accidentally deleted

### DIFF
--- a/rules/00188.json
+++ b/rules/00188.json
@@ -1,0 +1,26 @@
+{
+    "crime": "Get the address of a SMS message",
+    "permission": [],
+    "api": [
+        {
+            "class": "Landroid/content/ContentResolver;",
+            "method": "query",
+            "descriptor": "(Landroid/net/Uri; [Ljava/lang/String; Ljava/lang/String; [Ljava/lang/String; Ljava/lang/String;)Landroid/database/Cursor;",
+            "match_keywords": [
+                "sms"
+            ]
+        },
+        {
+            "class": "Landroid/database/Cursor;",
+            "method": "getColumnIndex",
+            "descriptor": "(Ljava/lang/String;)I",
+            "match_keywords": [
+                "address"
+            ]
+        }
+    ],
+    "score": 0.75,
+    "label": [
+        "sms"
+    ]
+}


### PR DESCRIPTION
This PR restores rules/00188.json which was accidentally deleted by https://github.com/ev-flow/quark-rules/pull/57. ([Link](https://github.com/ev-flow/quark-rules/pull/57/changes#diff-d068ec0824294ec336713576feab25324bff799a46e7ec08cb89f9ed318723bc))